### PR TITLE
Update culori

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,12 +8,13 @@
 			"name": "color-id-new",
 			"version": "0.0.1",
 			"dependencies": {
-				"culori": "github:bijela-gora/culori#d810061"
+				"culori": "^4.0.1"
 			},
 			"devDependencies": {
 				"@playwright/test": "^1.22.2",
 				"@sveltejs/adapter-node": "^1.2.0",
 				"@sveltejs/kit": "^1.5.0",
+				"@types/culori": "^2.1.0",
 				"@typescript-eslint/eslint-plugin": "^5.45.0",
 				"@typescript-eslint/parser": "^5.45.0",
 				"eslint": "^8.28.0",
@@ -685,6 +686,12 @@
 			"integrity": "sha512-COUnqfB2+ckwXXSFInsFdOAWQzCCx+a5hq2ruyj+Vjund94RJQd4LG2u9hnvJrTgunKAaax7ancBYlDrNYxA0g==",
 			"dev": true
 		},
+		"node_modules/@types/culori": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@types/culori/-/culori-2.1.0.tgz",
+			"integrity": "sha512-4uJT5CcC9Mi8mACkWShsPHqILMWL0OqoTsfoLJUGzN1mcipcepmmEdzU8b9L1KwyRNN3rnQO39ylI/2VR850zw==",
+			"dev": true
+		},
 		"node_modules/@types/estree": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.0.tgz",
@@ -1195,9 +1202,9 @@
 			}
 		},
 		"node_modules/culori": {
-			"version": "2.0.3",
-			"resolved": "git+ssh://git@github.com/bijela-gora/culori.git#d810061011de6d12e7c01164ba01d892952e575b",
-			"license": "MIT",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/culori/-/culori-4.0.1.tgz",
+			"integrity": "sha512-LSnjA6HuIUOlkfKVbzi2OlToZE8OjFi667JWN9qNymXVXzGDmvuP60SSgC+e92sd7B7158f7Fy3Mb6rXS5EDPw==",
 			"engines": {
 				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
 			}

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
 		"@playwright/test": "^1.22.2",
 		"@sveltejs/adapter-node": "^1.2.0",
 		"@sveltejs/kit": "^1.5.0",
+		"@types/culori": "^2.1.0",
 		"@typescript-eslint/eslint-plugin": "^5.45.0",
 		"@typescript-eslint/parser": "^5.45.0",
 		"eslint": "^8.28.0",
@@ -33,6 +34,6 @@
 	},
 	"type": "module",
 	"dependencies": {
-		"culori": "github:bijela-gora/culori#d810061"
+		"culori": "^4.0.1"
 	}
 }


### PR DESCRIPTION
# Objective

Previously, type definitions were only provided on a prototype branch, which we were using as a git dependency.
This branch has since been removed and the type definitions moved to `@types/culori`.

# Solution

- Update `culori` to the latest version published on `npm`.
- Use the `@types/culori` type definitions.