### PR TITLE
Use finer grained steps for contrast recommendations

### DIFF
--- a/src/lib/accessibility/ContrastChecks.svelte
+++ b/src/lib/accessibility/ContrastChecks.svelte
@@ -70,7 +70,7 @@
 		result: WcagResult;
 	}
 
-	const lightnessSteps = 0.05;
+	const lightnessSteps = 0.005;
 
 	function findBetterColor(comparisonColor: Hsl, changingColor: Hsl, targetContrast: number) {
 		const whiteContrast = wcagContrast(comparisonColor, WHITE);


### PR DESCRIPTION
# Objective

The contrast checker gradually increases or decreases the color lightness to recommend a color with better contrast.
The current system has steps which are too big, causing the recommended colors to differ too much from the original.

# Solution

Decrease the step size by a factor of 10.